### PR TITLE
Fixed issue when using a raw array key

### DIFF
--- a/helpers/wallet.ts
+++ b/helpers/wallet.ts
@@ -6,7 +6,8 @@ import { derivePath } from 'ed25519-hd-key';
 export function getWallet(wallet: string): Keypair {
   // most likely someone pasted the private key in binary format
   if (wallet.startsWith('[')) {
-    return Keypair.fromSecretKey(JSON.parse(wallet));
+    const raw = new Uint8Array(JSON.parse(wallet))
+    return Keypair.fromSecretKey(raw);
   }
 
   // most likely someone pasted mnemonic


### PR DESCRIPTION
This is a fix to an issue that happens when creating a keypair from a raw secret key byte array. the parsed array should be loaded to a Uint8Array object before calling `Keypair.fromSecretKey()`