### PR TITLE
Fix burn and renounced filters

### DIFF
--- a/filters/burn.filter.ts
+++ b/filters/burn.filter.ts
@@ -12,11 +12,7 @@ export class BurnFilter implements Filter {
       const burned = amount.value.uiAmount === 0;
       return { ok: burned, message: burned ? undefined : "Burned -> Creator didn't burn LP" };
     } catch (e: any) {
-      if (e.code == -32602) {
-        return { ok: true };
-      }
-
-      logger.error({ mint: poolKeys.baseMint }, `Failed to check if LP is burned`);
+      logger.error({ mint: poolKeys.baseMint, error: e }, `Burned -> Failed to check if LP is burned`);
     }
 
     return { ok: false, message: 'Failed to check if LP is burned' };

--- a/filters/renounced.filter.ts
+++ b/filters/renounced.filter.ts
@@ -29,16 +29,16 @@ export class RenouncedFreezeFilter implements Filter {
       }
 
       const deserialize = MintLayout.decode(accountInfo.data);
-      const renounced = !this.checkRenounced || deserialize.mintAuthorityOption === 0;
-      const freezable = !this.checkFreezable || deserialize.freezeAuthorityOption !== 0;
-      const ok = renounced && !freezable;
+      const renouncedOK = !this.checkRenounced || (deserialize.mintAuthorityOption === 0);
+      const freezeOK = !this.checkFreezable || (deserialize.freezeAuthorityOption === 0 && (deserialize.freezeAuthority === null || deserialize.freezeAuthority.equals(PublicKey.default)));
+      const ok = renouncedOK && freezeOK;
       const message: string[] = [];
 
-      if (!renounced) {
+      if (!renouncedOK) {
         message.push('mint');
       }
 
-      if (freezable) {
+      if (!freezeOK) {
         message.push('freeze');
       }
 

--- a/filters/renounced.filter.ts
+++ b/filters/renounced.filter.ts
@@ -1,6 +1,6 @@
 import { Filter, FilterResult } from './pool-filters';
 import { MintLayout } from '@solana/spl-token';
-import { Connection } from '@solana/web3.js';
+import { Connection, PublicKey } from '@solana/web3.js';
 import { LiquidityPoolKeysV4 } from '@raydium-io/raydium-sdk';
 import { logger } from '../helpers';
 


### PR DESCRIPTION
Fixing the burn filter by removing the check for error -32602. Otherwise this filter catches non-burned token.

Fixing the freeze filter by checking if the freezeAuthority address is either null or set to to a null address. Otherwise this filter catches freezable tokens.

Also fixes an issue where setting renounce to true and freezable to false would reject every token.