### PR TITLE
added missing package to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "^3.2.1",
+    "@metaplex-foundation/umi": "^0.9.2",
     "@raydium-io/raydium-sdk": "^1.3.1-beta.47",
     "@solana/spl-token": "^0.4.0",
     "@solana/web3.js": "^1.89.1",


### PR DESCRIPTION
This fixes the following error from the compilation with ts-node:
filters/mutable.filter.ts:6:28 - error TS2307: Cannot find module '@metaplex-foundation/umi/serializers' or its corresponding type declarations.

6 import { Serializer } from '@metaplex-foundation/umi/serializers';